### PR TITLE
Add docker compose file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,3 +88,14 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         run: go test -race $(go list ./... | grep -v third_party/)
 
+  e2e-tests:
+    name: Run E2E tests
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Run docker compose
+        run: docker compose -f compose.yml up -d --build

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ FROM golang:1.24.0@sha256:2b1cbf278ce05a2a310a3d695ebb176420117a8cfcfcc4e5e68a1b
 COPY --from=builder /opt/app-root/src/rekor-server /usr/local/bin/rekor-server
 
 # Set the binary as the entrypoint of the container
-CMD ["rekor-server", "server"]
+CMD ["rekor-server", "serve"]
 
 # debug compile options & debugger
 FROM deploy as debug

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,37 @@
+#
+# Copyright 2025 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+services:
+  spanner:
+    image: gcr.io/cloud-spanner-emulator/emulator@sha256:4c5deadfc50f5165270a6d8672290b1545c91dcf54ab69fc3cb2255a6ff736bf
+  gcs:
+    image: fsouza/fake-gcs-server@sha256:d47b4cf8b87006cab8fbbecfa5f06a2a3c5722e464abddc0d107729663d40ec4
+    volumes:
+    - bucket:/data/tiles:rw"
+    command:
+    - "-scheme=http"
+    - "-port=8080"
+  rekor:
+    build:
+      context: .
+      target: deploy
+    environment:
+    - SPANNER_EMULATOR_HOST=spanner:9010
+    - STORAGE_EMULATOR_HOST=gcp:8080
+    depends_on:
+    - spanner
+    - gcs
+volumes:
+  bucket: {}


### PR DESCRIPTION
Add compose.yml to easily start the GCP emulator services for development and CI. Adds an initial starting point for E2E tests.