### PR TITLE
Add support for freezing the log

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,3 +115,16 @@ jobs:
         run: docker compose -f compose.yml up -d --build --wait --wait-timeout 60
       - name: Run e2e tests
         run: go test -v -tags=e2e ./tests/
+
+  sharding:
+    name: Run freeze log tests
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Run freeze tests
+        run:
+          ./tests/freeze-test.sh

--- a/cmd/freeze-checkpoint/app/root.go
+++ b/cmd/freeze-checkpoint/app/root.go
@@ -1,0 +1,232 @@
+//
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+
+	gcs "cloud.google.com/go/storage"
+	rekornote "github.com/sigstore/rekor-tiles/pkg/note"
+	"github.com/sigstore/rekor-tiles/pkg/signerverifier"
+	"github.com/sigstore/sigstore/pkg/signature"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	logformat "github.com/transparency-dev/formats/log"
+	"github.com/transparency-dev/trillian-tessera/api/layout"
+	"golang.org/x/mod/sumdb/note"
+)
+
+const (
+	frozenString = "Log frozen — "
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "freeze-checkpoint",
+	Short: "Freeze the log checkpoint",
+	Long:  `Add an extension line to the final checkpoint to indicate to consumers that no more checkpoints are going to be published. Only supported for GCP.`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		ctx := cmd.Context()
+
+		if viper.GetString("gcp-bucket") == "" {
+			slog.Error("must provide --gcs-bucket")
+			os.Exit(1)
+		}
+		if viper.GetString("hostname") == "" {
+			slog.Error("must provide --hostname for the rekor server's identity")
+			os.Exit(1)
+		}
+
+		sv, err := getSignerVerifier(ctx)
+		if err != nil {
+			slog.Error(err.Error())
+			os.Exit(1)
+		}
+		noteSigner, err := getNoteSigner(ctx, sv)
+		if err != nil {
+			slog.Error(err.Error())
+			os.Exit(1)
+		}
+		noteVerifier, err := getNoteVerifier(sv)
+		if err != nil {
+			slog.Error(err.Error())
+			os.Exit(1)
+		}
+
+		objReader, objWriter, err := objectAccess(ctx)
+		if err != nil {
+			slog.Error(err.Error())
+			os.Exit(1)
+		}
+
+		checkpoint, err := getCheckpoint(objReader, noteVerifier)
+		if err != nil {
+			slog.Error(err.Error())
+			os.Exit(1)
+		}
+		if checkpoint == nil {
+			slog.Info("log is already frozen")
+			return
+		}
+
+		err = updateCheckpoint(objWriter, noteSigner, checkpoint)
+		if err != nil {
+			slog.Error(err.Error())
+			os.Exit(1)
+		}
+
+		if err := objWriter.Close(); err != nil {
+			slog.Error("closing object writer", "error", err.Error())
+			os.Exit(1)
+		}
+		slog.Info("Log frozen")
+	},
+}
+
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		slog.Error(err.Error())
+		os.Exit(1)
+	}
+}
+
+func init() {
+	rootCmd.Flags().String("gcp-bucket", "", "GCS bucket for tile and checkpoint storage")
+	rootCmd.Flags().String("hostname", "", "public hostname, used as the checkpoint origin")
+	rootCmd.Flags().String("signer-filepath", "", "path to the signing key")
+	rootCmd.Flags().String("signer-password", "", "password to decrypt the signing key")
+	rootCmd.Flags().String("signer-kmskey", "", "URI of the KMS key, in the form of awskms://keyname, azurekms://keyname, gcpkms://keyname, or hashivault://keyname")
+	rootCmd.Flags().String("signer-kmshash", "sha256", "hash algorithm used by the KMS")
+	rootCmd.Flags().String("signer-tink-kek-uri", "", "encryption key for decrypting Tink keyset. Valid options are [aws-kms://keyname, gcp-kms://keyname]")
+	rootCmd.Flags().String("signer-tink-keyset-path", "", "path to encrypted Tink keyset")
+
+	if err := viper.BindPFlags(rootCmd.Flags()); err != nil {
+		slog.Error(err.Error())
+		os.Exit(1)
+	}
+}
+
+var hashAlgMap = map[string]crypto.Hash{
+	"sha256": crypto.SHA256,
+	"sha384": crypto.SHA384,
+	"sha512": crypto.SHA512,
+}
+
+func getSignerVerifier(ctx context.Context) (signature.SignerVerifier, error) {
+	var opts []signerverifier.Option
+	switch {
+	case viper.GetString("signer-filepath") != "":
+		opts = []signerverifier.Option{signerverifier.WithFile(viper.GetString("signer-filepath"), viper.GetString("signer-password"))}
+	case viper.GetString("signer-kmskey") != "":
+		kmshash := viper.GetString("signer-kmshash")
+		hashAlg, ok := hashAlgMap[kmshash]
+		if !ok {
+			return nil, fmt.Errorf("invalid hash algorithm for --signer-kmshash: %s", kmshash)
+		}
+		opts = []signerverifier.Option{signerverifier.WithKMS(viper.GetString("signer-kmskey"), hashAlg)}
+	case viper.GetString("signer-tink-kek-uri") != "":
+		opts = []signerverifier.Option{signerverifier.WithTink(viper.GetString("signer-tink-kek-uri"), viper.GetString("signer-tink-keyset-path"))}
+	default:
+		return nil, fmt.Errorf("must provide a signer using a file, KMS, or Tink")
+	}
+	signerVerifier, err := signerverifier.New(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("initializing key signer: %w", err)
+	}
+	return signerVerifier, nil
+}
+
+func getNoteSigner(ctx context.Context, signer signature.Signer) (note.Signer, error) {
+	origin := viper.GetString("hostname")
+	noteSigner, err := rekornote.NewNoteSigner(ctx, origin, signer)
+	if err != nil {
+		return nil, fmt.Errorf("initializing note signer: %w", err)
+	}
+	return noteSigner, nil
+}
+
+func getNoteVerifier(verifier signature.Verifier) (note.Verifier, error) {
+	origin := viper.GetString("hostname")
+	noteVerifier, err := rekornote.NewNoteVerifier(origin, verifier)
+	if err != nil {
+		return nil, fmt.Errorf("initializing note verifier: %w", err)
+	}
+	return noteVerifier, nil
+}
+
+func objectAccess(ctx context.Context) (*gcs.Reader, *gcs.Writer, error) {
+	client, err := gcs.NewClient(ctx, gcs.WithJSONReads())
+	if err != nil {
+		return nil, nil, fmt.Errorf("getting GCS client: %w", err)
+	}
+	bucketName := viper.GetString("gcp-bucket")
+	object := client.Bucket(bucketName).Object(layout.CheckpointPath)
+	objReader, err := object.NewReader(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("getting object reader: %w", err)
+	}
+	contentType := "text/plain; charset=utf-8"
+	objWriter := object.NewWriter(ctx)
+	objWriter.ContentType = contentType
+	return objReader, objWriter, nil
+}
+
+func getCheckpoint(objReader *gcs.Reader, noteVerifier note.Verifier) (*logformat.Checkpoint, error) {
+	rawCheckpoint, err := io.ReadAll(objReader)
+	if err != nil {
+		return nil, fmt.Errorf("reading object: %w", err)
+	}
+	noteObj, err := note.Open(rawCheckpoint, note.VerifierList(noteVerifier))
+	if err != nil {
+		return nil, fmt.Errorf("opening checkpoint: %w", err)
+	}
+	checkpoint := logformat.Checkpoint{}
+	rest, err := checkpoint.Unmarshal([]byte(noteObj.Text))
+	if err != nil {
+		return nil, fmt.Errorf("parsing checkpoint: %w", err)
+	}
+	if strings.Contains(string(rest), frozenString) {
+		return nil, nil
+	}
+	return &checkpoint, nil
+}
+
+// updateCheckpoint writes an extension line to the checkpoint note to indicate the checkpoint is frozen,
+// re-signs it and re-uploads it to the GCS backend.
+func updateCheckpoint(objWriter *gcs.Writer, noteSigner note.Signer, checkpoint *logformat.Checkpoint) error {
+	// Marshaled checkpoint contains the origin, size, and hash of the checkpoint, not the signatures.
+	// The final checkpoint object will contain the origin, size, hash, extension line, and signature.
+	buf := bytes.NewBuffer(checkpoint.Marshal())
+	buf.WriteString(frozenString)
+	now := time.Now().UTC().Format(time.UnixDate)
+	buf.WriteString(now)
+	buf.WriteString("\n")
+	signedNote, err := note.Sign(&note.Note{Text: buf.String()}, noteSigner)
+	if err != nil {
+		return fmt.Errorf("re-signing checkpoint: %w", err)
+	}
+	if _, err := objWriter.Write(signedNote); err != nil {
+		return fmt.Errorf("writing checkpoint: %w", err)
+	}
+	return nil
+}

--- a/cmd/freeze-checkpoint/main.go
+++ b/cmd/freeze-checkpoint/main.go
@@ -1,0 +1,22 @@
+//
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "github.com/sigstore/rekor-tiles/cmd/freeze-checkpoint/app"
+
+func main() {
+	app.Execute()
+}

--- a/compose.yml
+++ b/compose.yml
@@ -72,6 +72,7 @@ services:
       - curl http://localhost:3000/healthz | grep '{"status":"SERVING"}'
       timeout: 30s
       retries: 10
+      interval: 3s
       # requires docker engine >= v25
       # start_period: 5s
       # start_interval: 1s

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/sigstore/rekor-tiles
 go 1.24.0
 
 require (
+	cloud.google.com/go/storage v1.51.0
 	github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3
@@ -45,7 +46,6 @@ require (
 	cloud.google.com/go/longrunning v0.6.5 // indirect
 	cloud.google.com/go/monitoring v1.24.0 // indirect
 	cloud.google.com/go/spanner v1.77.0 // indirect
-	cloud.google.com/go/storage v1.51.0 // indirect
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.2 // indirect

--- a/pkg/note/note_test.go
+++ b/pkg/note/note_test.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/sigstore/rekor-tiles/pkg/signer"
+	"github.com/sigstore/rekor-tiles/pkg/signerverifier"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -108,7 +108,7 @@ func TestKeyHash(t *testing.T) {
 			if err := os.WriteFile(keyFile, []byte(test.key), 0644); err != nil {
 				t.Fatal(err)
 			}
-			signer, err := signer.New(ctx, signer.WithFile(keyFile, ""))
+			signer, err := signerverifier.New(ctx, signerverifier.WithFile(keyFile, ""))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/server/service_test.go
+++ b/pkg/server/service_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestNewServer(t *testing.T) {
 	storage := &mockStorage{}
-	server := NewServer(storage)
+	server := NewServer(storage, false)
 	expectServer := &Server{storage: &mockStorage{}}
 	assert.Equal(t, expectServer, server)
 }
@@ -138,7 +138,7 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEeLw7gX40qy1z7JUhGMAaaDITbV7p
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			storage := &mockStorage{addFn: test.addFn}
-			server := NewServer(storage)
+			server := NewServer(storage, false)
 			gotTle, gotErr := server.CreateEntry(context.Background(), test.req)
 			if test.expectError == nil {
 				assert.NoError(t, gotErr)

--- a/pkg/signerverifier/file.go
+++ b/pkg/signerverifier/file.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Copied from https://github.com/sigstore/rekor/blob/c820fcaf3afdc91f0acf6824d55c1ac7df249df1/pkg/signer/file.go
 
-package signer
+package signerverifier
 
 import (
 	"fmt"
@@ -30,16 +30,16 @@ type File struct {
 	signature.SignerVerifier
 }
 
-// NewFileSigner returns an file-based signer and verify, used for spinning up local instances.
-func NewFileSigner(keyPath, keyPass string) (*File, error) {
+// NewFileSignerVerifier returns an file-based signer-verifier, used for spinning up local instances.
+func NewFileSignerVerifier(keyPath, keyPass string) (*File, error) {
 	opaqueKey, err := pemutil.Read(keyPath, pemutil.WithPassword([]byte(keyPass)))
 	if err != nil {
 		return nil, fmt.Errorf("file: provide a valid signer, %s is not valid: %w", keyPath, err)
 	}
 
-	signer, err := signature.LoadDefaultSignerVerifier(opaqueKey)
+	signerVerifier, err := signature.LoadDefaultSignerVerifier(opaqueKey)
 	if err != nil {
 		return nil, fmt.Errorf(`file: loaded private key from %s can't be used to sign: %w`, keyPath, err)
 	}
-	return &File{signer}, nil
+	return &File{signerVerifier}, nil
 }

--- a/pkg/signerverifier/file_test.go
+++ b/pkg/signerverifier/file_test.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Copied from https://github.com/sigstore/rekor/blob/c820fcaf3afdc91f0acf6824d55c1ac7df249df1/pkg/signer/file_test.go
 
-package signer
+package signerverifier
 
 import (
 	"os"
@@ -65,7 +65,7 @@ func TestFile(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			tc := tc
-			_, err := NewFileSigner(tc.keyPath, tc.keyPass)
+			_, err := NewFileSignerVerifier(tc.keyPath, tc.keyPass)
 			if tc.wantErr != (err != nil) {
 				t.Errorf("NewFile() expected %t, got err %s", tc.wantErr, err)
 			}

--- a/pkg/signerverifier/tink.go
+++ b/pkg/signerverifier/tink.go
@@ -14,7 +14,7 @@
 
 // Copied from https://github.com/sigstore/rekor/blob/c820fcaf3afdc91f0acf6824d55c1ac7df249df1/pkg/signer/tink.go
 
-package signer
+package signerverifier
 
 import (
 	"context"
@@ -36,9 +36,9 @@ import (
 
 const TinkScheme = "tink"
 
-// NewTinkSignerWithHandle returns a signature.SignerVerifier that wraps crypto.Signer and a hash function.
+// NewTinkSignerVerifier returns a signature.SignerVerifier that wraps crypto.Signer and a hash function.
 // Provide a path to the encrypted keyset and cloud KMS key URI for decryption
-func NewTinkSigner(ctx context.Context, kekURI, keysetPath string) (signature.Signer, error) {
+func NewTinkSignerVerifier(ctx context.Context, kekURI, keysetPath string) (signature.SignerVerifier, error) {
 	if kekURI == "" || keysetPath == "" {
 		return nil, fmt.Errorf("key encryption key URI or keyset path unset")
 	}
@@ -46,12 +46,12 @@ func NewTinkSigner(ctx context.Context, kekURI, keysetPath string) (signature.Si
 	if err != nil {
 		return nil, err
 	}
-	return NewTinkSignerWithHandle(kek, keysetPath)
+	return NewTinkSignerVerifierWithHandle(kek, keysetPath)
 }
 
-// NewTinkSignerWithHandle returns a signature.SignerVerifier that wraps crypto.Signer and a hash function.
+// NewTinkSignerVerifierWithHandle returns a signature.SignerVerifier that wraps crypto.Signer and a hash function.
 // Provide a path to the encrypted keyset and a key handle for decrypting the keyset
-func NewTinkSignerWithHandle(kek tink.AEAD, keysetPath string) (signature.Signer, error) {
+func NewTinkSignerVerifierWithHandle(kek tink.AEAD, keysetPath string) (signature.SignerVerifier, error) {
 	f, err := os.Open(filepath.Clean(keysetPath))
 	if err != nil {
 		return nil, err

--- a/pkg/signerverifier/tink_test.go
+++ b/pkg/signerverifier/tink_test.go
@@ -14,7 +14,7 @@
 
 // Copied from https://github.com/sigstore/rekor/blob/c820fcaf3afdc91f0acf6824d55c1ac7df249df1/pkg/signer/tink_test.go
 
-package signer
+package signerverifier
 
 import (
 	"os"
@@ -61,7 +61,7 @@ func TestNewTinkCA(t *testing.T) {
 		t.Fatalf("error writing enc keyset: %v", err)
 	}
 
-	signer, err := NewTinkSignerWithHandle(a, keysetPath)
+	signer, err := NewTinkSignerVerifierWithHandle(a, keysetPath)
 	if err != nil {
 		t.Fatalf("unexpected error creating signer: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestNewTinkCA(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating AEAD key: %v", err)
 	}
-	_, err = NewTinkSignerWithHandle(aeadAlt, keysetPath)
+	_, err = NewTinkSignerVerifierWithHandle(aeadAlt, keysetPath)
 	if err == nil || !strings.Contains(err.Error(), "decryption failed") {
 		t.Fatalf("expected error decrypting keyset, got %v", err)
 	}

--- a/tests/freeze-test.sh
+++ b/tests/freeze-test.sh
@@ -1,0 +1,45 @@
+# /usr/bin/env bash
+# Copyright 2025 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+export STORAGE_EMULATOR_HOST=localhost:7080
+
+docker compose up -d --build --wait --wait-timeout 60
+cleanup() {
+	echo "cleaning up"
+	docker compose down
+}
+trap cleanup EXIT
+
+echo "running pre-freeze tests"
+go test -v -tags=e2e,freeze -run TestPreFreeze ./tests
+
+echo "setting rekor to read-only"
+composefile=compose.yml.tmp
+sed -e '/"serve"/a\' -e '    - "--read-only"' compose.yml > $composefile
+cleanup_tmp() {
+	cleanup
+	rm $composefile
+}
+trap cleanup_tmp EXIT
+
+docker compose down rekor && docker compose -f $composefile up -d rekor --wait --wait-timeout 60
+
+echo "freezing checkpoint"
+go run cmd/freeze-checkpoint/main.go --gcp-bucket "tiles" --signer-filepath tests/testdata/pki/ed25519-priv-key.pem --hostname rekor-local
+
+echo "running post-freeze tests"
+go test -v -tags=e2e,freeze -run TestPostFreeze ./tests

--- a/tests/freeze_test.go
+++ b/tests/freeze_test.go
@@ -1,0 +1,103 @@
+//
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e && freeze
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sigstore/rekor-tiles/pkg/client/read"
+	"github.com/sigstore/rekor-tiles/pkg/client/write"
+	"github.com/sigstore/rekor-tiles/pkg/signerverifier"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	defaultServerPrivateKey = "./testdata/pki/ed25519-priv-key.pem"
+)
+
+func setup(ctx context.Context) (read.Client, write.Client, error) {
+	// get verifier needed for both read and write
+	verifier, err := signerverifier.New(ctx, signerverifier.WithFile(defaultServerPrivateKey, ""))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// reader client
+	reader, err := read.NewReader(defaultGCSURL, defaultRekorHostname, verifier)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// writer client
+	writer, err := write.NewWriter(defaultRekorURL, defaultRekorHostname, verifier)
+	if err != nil {
+		return nil, nil, err
+	}
+	return reader, writer, nil
+}
+
+func TestPreFreeze(t *testing.T) {
+	ctx := context.Background()
+	reader, writer, err := setup(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkpoint, note, err := reader.ReadCheckpoint(ctx)
+	assert.NoError(t, err)
+	assert.NotNil(t, checkpoint)
+	assert.NotNil(t, note)
+	assert.NotContains(t, string(note.Text), "Log frozen —")
+
+	clientPrivKey, clientPubKey, err := genKeys()
+	if err != nil {
+		t.Fatal(err)
+	}
+	hr, err := newHashedRekordRequest(clientPrivKey, clientPubKey, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = writer.Add(ctx, hr)
+	assert.NoError(t, err)
+}
+
+func TestPostFreeze(t *testing.T) {
+	ctx := context.Background()
+	reader, writer, err := setup(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkpoint, note, err := reader.ReadCheckpoint(ctx)
+	assert.NoError(t, err)
+	assert.NotNil(t, checkpoint)
+	assert.NotNil(t, note)
+	assert.Contains(t, string(note.Text), "Log frozen —")
+
+	clientPrivKey, clientPubKey, err := genKeys()
+	if err != nil {
+		t.Fatal(err)
+	}
+	hr, err := newHashedRekordRequest(clientPrivKey, clientPubKey, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tle, err := writer.Add(ctx, hr)
+	assert.Nil(t, tle)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected response: 405 This log has been frozen, please switch to the latest log.")
+}


### PR DESCRIPTION
Add a flag that, when Rekor is restarted, prevents the service from accepting new entries or publishing new checkpoints. Add a command to publish a final checkpoint that contains an extension indicating the log is frozen.

Technically Rekor could be fully shut down and it would accomplish the same purpose of not accepting new entries or updating new checkpoints. The server change is mostly useful in the potential future when Rekor needs to be responsible for serving checkpoints stored in MySQL. The freeze command is necessary no matter the backend.